### PR TITLE
選択した素材をパターン選択画面でも表示する

### DIFF
--- a/androidApp/home/src/main/java/tech/takahana/iconwallpaper/android/home/ui/screen/HomeSelectPatternContent.kt
+++ b/androidApp/home/src/main/java/tech/takahana/iconwallpaper/android/home/ui/screen/HomeSelectPatternContent.kt
@@ -39,9 +39,11 @@ import tech.takahana.iconwallpaper.android.home.R
 import tech.takahana.iconwallpaper.android.home.ui.components.ImagePattern
 import tech.takahana.iconwallpaper.android.home.ui.components.StepAnnouncement
 import tech.takahana.iconwallpaper.android.home.ui.screen.viewmodel.HomeSelectPatternViewModel
+import tech.takahana.iconwallpaper.shared.assets.LocalImageAsset
 import tech.takahana.iconwallpaper.uilogic.home.HomeSelectBackgroundColorUiLogic
 import tech.takahana.iconwallpaper.uilogic.home.HomeSelectPatternUiLogic
 import tech.takahana.iconwallpaper.uilogic.home.HomeSwitchTabUiLogic
+import tech.takahana.iconwallpaper.uilogic.home.ImageAssetUiModel
 import tech.takahana.iconwallpaper.uilogic.home.SwitchTabUiModel
 
 @Composable
@@ -53,25 +55,35 @@ fun HomeSelectPatternContent(
     selectBackgroundColorUiLogic: HomeSelectBackgroundColorUiLogic = viewModel.selectBackgroundColorUiLogic,
     switchTabUiLogic: HomeSwitchTabUiLogic = viewModel.switchTabUiLogic
 ) {
-
-    HomeSelectPatternImageAssetSelected(
-        modifier = modifier,
-        homeNavController = homeNavController,
-        selectPatternUiLogic = selectPatternUiLogic,
-        selectBackgroundColorUiLogic = selectBackgroundColorUiLogic,
-        switchTabUiLogic = switchTabUiLogic,
-    )
+    when (val imageAssetUiModel = selectPatternUiLogic.selectedImageAssetStateFlow.value) {
+        ImageAssetUiModel.None -> TODO("素材選択ページに戻す")
+        is ImageAssetUiModel.Selectable -> {
+            val localImageAsset = imageAssetUiModel.imageAsset as? LocalImageAsset
+            if (localImageAsset != null) {
+                HomeSelectPatternImageAssetSelected(
+                    modifier = modifier,
+                    homeNavController = homeNavController,
+                    imageAsset = localImageAsset,
+                    selectPatternUiLogic = selectPatternUiLogic,
+                    selectBackgroundColorUiLogic = selectBackgroundColorUiLogic,
+                    switchTabUiLogic = switchTabUiLogic,
+                )
+            } else {
+                TODO("素材選択ページに戻す")
+            }
+        }
+    }
 }
 
 @Composable
 private fun HomeSelectPatternImageAssetSelected(
     modifier: Modifier = Modifier,
     homeNavController: NavController,
+    imageAsset: LocalImageAsset,
     selectPatternUiLogic: HomeSelectPatternUiLogic,
     selectBackgroundColorUiLogic: HomeSelectBackgroundColorUiLogic,
     switchTabUiLogic: HomeSwitchTabUiLogic,
 ) {
-    val resId = R.drawable.cat
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -89,7 +101,7 @@ private fun HomeSelectPatternImageAssetSelected(
         ) {
             ImagePattern(
                 patternType = patternType,
-                resourceId = resId
+                resourceId = imageAsset.resId,
             )
         }
         Row(
@@ -139,7 +151,7 @@ private fun HomeSelectPatternImageAssetSelected(
         ) {
             if (tabState == SwitchTabUiModel.PATTERN) HomeSelectPatternTab(
                 selectPatternUiLogic = selectPatternUiLogic,
-                resId = resId,
+                resId = imageAsset.resId,
                 patternType = patternType,
                 backgroundColor = backgroundColor
             ) else HomeSelectBackgroundTab(

--- a/androidApp/home/src/main/java/tech/takahana/iconwallpaper/android/home/ui/screen/HomeSelectPatternContent.kt
+++ b/androidApp/home/src/main/java/tech/takahana/iconwallpaper/android/home/ui/screen/HomeSelectPatternContent.kt
@@ -53,6 +53,24 @@ fun HomeSelectPatternContent(
     selectBackgroundColorUiLogic: HomeSelectBackgroundColorUiLogic = viewModel.selectBackgroundColorUiLogic,
     switchTabUiLogic: HomeSwitchTabUiLogic = viewModel.switchTabUiLogic
 ) {
+
+    HomeSelectPatternImageAssetSelected(
+        modifier = modifier,
+        homeNavController = homeNavController,
+        selectPatternUiLogic = selectPatternUiLogic,
+        selectBackgroundColorUiLogic = selectBackgroundColorUiLogic,
+        switchTabUiLogic = switchTabUiLogic,
+    )
+}
+
+@Composable
+private fun HomeSelectPatternImageAssetSelected(
+    modifier: Modifier = Modifier,
+    homeNavController: NavController,
+    selectPatternUiLogic: HomeSelectPatternUiLogic,
+    selectBackgroundColorUiLogic: HomeSelectBackgroundColorUiLogic,
+    switchTabUiLogic: HomeSwitchTabUiLogic,
+) {
     val resId = R.drawable.cat
     Column(
         modifier = modifier,
@@ -69,7 +87,10 @@ fun HomeSelectPatternContent(
                 .background(color = Color(backgroundColor.hex)),
             contentAlignment = Alignment.Center
         ) {
-            ImagePattern(patternType = patternType, resourceId = resId)
+            ImagePattern(
+                patternType = patternType,
+                resourceId = resId
+            )
         }
         Row(
             horizontalArrangement = Arrangement.SpaceBetween


### PR DESCRIPTION
<!---
Assigneesに自身を追加してください。
Reviewersに最低でも@Takahanaを追加してください
-->

## 対応内容
<!---
関連するissueがあれば、その番号を書いてください。

issueを閉じる場合
close #999999
-->

素材一覧ページで選択したものをパターン選択ページで表示できるようにしました。

※素材選択したらボタンの表示を変える処理は別のPRで実装します。

## レビューで見てほしいこと

## スクリーンショット
<!---
デザインを修正した時にはスクショを貼ってください。
-->

※ `LocalImageAssetRepositoryImpl` を修正して、チェックマークも表示できるようにしています。

<details close>
<summary>LocalImageAssetRepositoryImpl</summary>

```kotlin
class LocalImageAssetRepositoryImpl : LocalImageAssetRepository {

    override fun getAll(): List<LocalImageAsset> = (1..100).map { num ->
        if (num % 2 == 0) {
            LocalImageAsset(
                id = AssetId("cat_$num"),
                name = AssetName("cat"),
                resId = R.drawable.cat
            )
        } else {
            LocalImageAsset(
                id = AssetId("check_$num"),
                name = AssetName("check"),
                resId = R.drawable.ic_check_circle_24
            )
        }
    }
}
```

</details>

<video src="https://user-images.githubusercontent.com/22670961/185773433-6f612eff-853f-4719-aaf5-f973d9a24dd8.mp4" />

